### PR TITLE
Change background color for theme compatability

### DIFF
--- a/octoprint_cancelobject/static/css/cancelobject.css
+++ b/octoprint_cancelobject/static/css/cancelobject.css
@@ -22,11 +22,11 @@
 }
 
 div.entries > div:nth-of-type(odd) {
-    background-color: #e0e0e0;
+    background-color: transparent;
 }
 
 div.entries > div:nth-of-type(even) {
-    background-color: #E4F0EF;
+    background-color: transparent;
 }
 
 div.gcode_canvas_wrapper1 {

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_cancelobject"
 plugin_name = "OctoPrint-Cancelobject"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.2"
+plugin_version = "0.3.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
The different colors for odd and non-odd nombers looks neat and all, but as the colors are very light it looks bad if you use it on anything but the standard OctoPrint theme. Change them to transparent to solve this issue. (It could also be changed to have different colors for odd and non-odd numbers, but if so I would recommend to make the colors translucent).