### PR TITLE
Updates to improve compatibility with the ExcludeRegion plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ See below for instructions for specific slicers.
 * It is designed for use with Marlin and Marlin-flavored firmwares. The behaviour with other firmwares is unknown.
 * Gcodeviewer integration requires that the object has to have had some printing moves before its coordinates are known. Use the `Refresh Objects` button to update.
 * Some slicers will place first layer extras (brim, raft, etc.) as part of an object. If this throws off the position of the objects in the gcodeviewer you can use the `Reset Objects` button.
-* There are known issues when this plugin and the ExcludeRegion plugin are used together. In theory, they can be used together. However, object markers are not automatically refreshed on moving/scaling if ExcludeRegion is active. Use the `Refresh Objects` button to render them again.
 ## Setup
 
 Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)


### PR DESCRIPTION
Hi there, I noticed there were some compatibility issues between our two plugins.  This PR should help resolve issues with the Gcode viewer acting strange when they are both installed.

The basic problem is with how the onViewportChange handler is hooked.  It was implemented as a single callback, instead of using a pub/sub model, so plugins that utilize it need to ensure that they retain and call any previously registered callback as a part of their own processing.  The code I had originally written didn't take that into account, so when two plugins with that code are installed they fight over the callback, with only one of them receiving the events.

I'll be releasing a new version of the ExcludeRegion plugin soon (code is in my [devel branch](https://github.com/bradcfisher/OctoPrint-ExcludeRegionPlugin/tree/devel)) with a similar update that will resolve the issue from my side.

I've done some light testing so far, and will be doing a bit more, though it wouldn't hurt to have another pass :)

Thanks!
-Brad

Changes Included:

- Chain to existing onViewportChange handler when hooking Gcode viewer (should address issues with ExcludeRegion plugin or other plugins that hook the same callback)
- Honor user login state for interface buttons to prevent unauthenticated users from affecting the print
- Only capture mouse clicks on the Gcode viewer when the object markers are visible.  Should improve compatibility with other plugins that hook the viewer when the markers are hidden.
- Removed some dead code (initializeControlsIfReady & gcodeViewerPollFn)
