### PR TITLE
Convert from unicode to string

### DIFF
--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -37,7 +37,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                 line = self._matchComment(line)
         if not len(line):
             return None
-        return line
+        return line.encode('ascii','ignore')
 
     def _matchComment(self, line):
         for pattern in self.patterns:


### PR DESCRIPTION
This PR fixes this error while trying to upload a gcode file

> 2020-01-08 19:56:51,335 - tornado.application - ERROR - Uncaught exception POST /api/files/local (::1)
HTTPServerRequest(protocol='http', host='localhost:5000', method='POST', uri='/api/files/local', version='HTTP/1.1', remote_ip='::1', headers={'Origin': 'http://localhost:5000', 'Accept-Language': 'en-US,en;q=0.9,es;q=0.8', 'Accept-Encoding': 'gzip, deflate, br', 'Sec-Fetch-Site': 'same-origin', 'Host': 'localhost:5000', 'Accept': 'application/json, text/javascript, */*; q=0.01', 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36', 'Connection': 'keep-alive', 'X-Requested-With': 'XMLHttpRequest', 'Sec-Fetch-Mode': 'cors', 'Cache-Control': 'no-cache', 'Cookie': '_ga=GA1.1.1429836465.1558858415; cookieconsent_status=dismiss; remember_token_P5000=gato|50600cbf049aeb5bdaf056fc1c4ca303a7b59051; session_P5000=.eJxNzcEKgkAYBOBXif8skVGXBQ9FJQSuYGroRbRddZdfDXdFTXz3yC5eZ_hmJkjylqsSSJ6i4gYkggGZYJMBAafykMozxtUdXf_V0wurnGdwjKRziPxioB9PUnk1XTuyYDZAMF5rocdt2uky0eObA6k7xFWzWo_3t13WW4vsFG-XZyhS3cA_UFwp0dRrw0IPmckeoT3I4PSz8xeRtUAN.XhakeQ.75wAH3T_pp9EWzX01WnlpCIKBkA'})
Traceback (most recent call last):
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/tornado/web.py", line 1510, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/Users/gaston/repo/OctoPrint/src/octoprint/server/util/tornado.py", line 501, in _handle_method
    self._fallback(self.request, body)
  File "/Users/gaston/repo/OctoPrint/src/octoprint/server/util/tornado.py", line 609, in __call__
    WsgiInputContainer.environ(request, body), start_response)
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/gaston/repo/OctoPrint/src/octoprint/server/util/flask.py", line 1276, in decorated_view
    return no_firstrun_access(flask_login.login_required(func))(*args, **kwargs)
  File "/Users/gaston/repo/OctoPrint/src/octoprint/server/util/flask.py", line 1295, in decorated_view
    return func(*args, **kwargs)
  File "/Users/gaston/repo/OctoPrint/venv/lib/python2.7/site-packages/flask_login.py", line 758, in decorated_view
    return func(*args, **kwargs)
  File "/Users/gaston/repo/OctoPrint/src/octoprint/server/api/files.py", line 361, in uploadGcodeFile
    display=canonFilename)
  File "/Users/gaston/repo/OctoPrint/src/octoprint/filemanager/__init__.py", line 493, in add_file
    path_in_storage = self._storage(destination).add_file(path, file_object, links=links, printer_profile=printer_profile, allow_overwrite=allow_overwrite, display=display)
  File "/Users/gaston/repo/OctoPrint/src/octoprint/filemanager/storage.py", line 765, in add_file
    file_object.save(file_path)
  File "/Users/gaston/repo/OctoPrint/src/octoprint/filemanager/util.py", line 92, in save
    shutil.copyfileobj(source, dest)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 66, in copyfileobj
    fdst.write(buf)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xb0' in position 10822: ordinal not in range(128)

The PR has been tested with 
1. Python 2 + OctoPrint 1.3.13
1. Python 3 + OctoPrint 1.4.0.rc3