### PR TITLE
M486

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Want to support this work? Buy Me a Coffee. https://www.buymeacoffee.com/ppaukst
 
 This plugin allows the user to interactively cancel objects in gcode based on comment tags added by the slicer.
 See below for instructions for specific slicers.
+### New version 0.5.0, 01/2024
+* Parse M486 commands and add necessary `@` commands. This circumvents forcing PrusaSlicer to use `OctoPrint` exclusively in the Label Objects output. There may be issues with other slicers that have not yet been tested.
+
 ### New version 0.4.2, 07/2020
 * Remove case sensitivity for `@Object` tags.
 * Improvements to absolute extrusion tracking.

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -73,7 +73,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
         matched = self.m486_control.match(line)
         if matched:
             last_m486 = int(matched.group(1))
-            self._console_logger("Matched {}".format(last_m486))
+            self._console_logger.info("Matched {}".format(last_m486))
             if last_m486 > -1:
                 obj_name = self._get_m846(last_m486)
                 if obj_name:

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -19,7 +19,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
     
     def __init__(self, fileBufferedReader, object_regex, reptag):
         super(ModifyComments, self).__init__(fileBufferedReader)
-        self._console_logger = logging.getLogger("octoprint.plugins.cancelobject")
+        #self._console_logger = logging.getLogger("octoprint.plugins.cancelobject")
         self.patterns = []
         for each in object_regex:
             if each["objreg"]:
@@ -73,11 +73,11 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
         matched = self.m486_control.match(line)
         if matched:
             last_m486 = int(matched.group(1))
-            self._console_logger.info("Matched {}".format(last_m486))
+            #self._console_logger.info("Matched {}".format(last_m486))
             if last_m486 != -1:
                 obj_name = self._get_m846(last_m486)
                 if obj_name:
-                    self._console_logger.info(obj_name)
+                    #self._console_logger.info(obj_name)
                     line = line+"{0} {1}\n".format(self._reptag, obj_name)
             else:
                 line = line+"{0}stop\n".format(self._reptag)
@@ -101,7 +101,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
             
         self.m486_list.append({"index": index, "name": None})
         self.last_m486 = index
-        self._console_logger.info(self.m486_list)
+        #self._console_logger.info(self.m486_list)
         return None
 
 # stolen directly from filaswitch, https://github.com/spegelius/filaswitch

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -16,9 +16,10 @@ from octoprint.events import Events
 from octoprint.filemanager import FileDestinations
 
 class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
-
+    
     def __init__(self, fileBufferedReader, object_regex, reptag):
         super(ModifyComments, self).__init__(fileBufferedReader)
+        self._console_logger = logging.getLogger("octoprint.plugins.cancelobject")
         self.patterns = []
         for each in object_regex:
             if each["objreg"]:

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -86,7 +86,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
         #if we didn't match a control, it is going to be the descriptor
         else:
             descriptor = self.m486_descriptor.match(line)
-            if descriptor and self.last_m486:
+            if descriptor:
                 for each in self.m486_list:
                     #each.update((name,descriptor.group(1)) for name, index in each.iteritems() if index == self.last_m486)
                     if each["index"] == self.last_m486:

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -88,7 +88,8 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                     #each.update((name,descriptor.group(1)) for name, index in each.iteritems() if index == self.last_m486)
                     if each["index"] == self.last_m486:
                         each["name"] = descriptor.group(1)
-                        self.last_m486 = None    
+                        self.last_m486 = None   
+        return line 
             
     def _get_m846(self, index):
         for each in self.m486_list:

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -77,7 +77,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                 obj_name = self._get_m846(last_m486)
                 if obj_name:
                     print(obj_name)
-                    line = line+"\{0} {1}\n".format(self._reptag, obj_name)
+                    line = line+"\n{0} {1}\n".format(self._reptag, obj_name)
                     return line
 
         #if we didn't match a control, it is going to be the descriptor
@@ -95,10 +95,10 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
         for each in self.m486_list:
             if each["index"] == index:
                 return each["name"]
-            else:
-                self.m486_list.append({"index": index, "name": None})
-                self.last_m486 = index
-                return None
+            
+        self.m486_list.append({"index": index, "name": None})
+        self.last_m486 = index
+        return None
 
 # stolen directly from filaswitch, https://github.com/spegelius/filaswitch
 class Gcode_parser:

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -72,12 +72,12 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
         matched = self.m486_control.match(line)
         if matched:
             last_m486 = int(matched.group(1))
-            print("Matched {}".format(last_m486))
+            self._console_logger("Matched {}".format(last_m486))
             if last_m486 > -1:
                 obj_name = self._get_m846(last_m486)
                 if obj_name:
-                    print(obj_name)
-                    line = line+"\n{0} {1}\n".format(self._reptag, obj_name)
+                    self._console_logger.info(obj_name)
+                    line = "{0} {1}\n".format(self._reptag, obj_name)
                     return line
 
         #if we didn't match a control, it is going to be the descriptor

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -28,7 +28,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
         self._reptag = "@{0}".format(reptag)
         self.infomatch = re.compile("; object:.*")
         self.stopmatch = re.compile("; stop printing object ([^\t\n\r\f\v]*)")
-        self.m486_control = re.compile("M486 S(\d+)|$") #matches end of line after digits
+        self.m486_control = re.compile("M486 S([-]*\d+)|$") #matches end of line after digits
         self.m486_descriptor = re.compile("M486 (.*)|$")
         self.last_m486 = None
         self.m486_list = []
@@ -78,7 +78,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                 obj_name = self._get_m846(last_m486)
                 if obj_name:
                     self._console_logger.info(obj_name)
-                    line = "{0} {1}\n".format(self._reptag, obj_name)
+                    line = line+"\n{0} {1}\n".format(self._reptag, obj_name)
                     return line
 
         #if we didn't match a control, it is going to be the descriptor

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -78,8 +78,10 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                 obj_name = self._get_m846(last_m486)
                 if obj_name:
                     self._console_logger.info(obj_name)
-                    line = line+"\n{0} {1}\n".format(self._reptag, obj_name)
+                    line = line+"{0} {1}\n".format(self._reptag, obj_name)
                     return line
+            else:
+                line = line+"{0}stop\n".format(self._reptag)
 
         #if we didn't match a control, it is going to be the descriptor
         else:

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -28,7 +28,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
         self._reptag = "@{0}".format(reptag)
         self.infomatch = re.compile("; object:.*")
         self.stopmatch = re.compile("; stop printing object ([^\t\n\r\f\v]*)")
-        self.m486_control = re.compile("M486 S([-]\d+)|$") #matches end of line after digits
+        self.m486_control = re.compile("M486 S(\d+)|$") #matches end of line after digits
         self.m486_descriptor = re.compile("M486 (.*)|$")
         self.last_m486 = None
         self.m486_list = []

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -79,10 +79,9 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                 if obj_name:
                     self._console_logger.info(obj_name)
                     line = line+"{0} {1}\n".format(self._reptag, obj_name)
-                    return line
             else:
                 line = line+"{0}stop\n".format(self._reptag)
-                return line
+                
 
         #if we didn't match a control, it is going to be the descriptor
         else:
@@ -93,7 +92,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                     if each["index"] == self.last_m486:
                         each["name"] = descriptor.group(1)
                         self.last_m486 = None   
-            return line 
+        return line 
             
     def _get_m846(self, index):
         for each in self.m486_list:
@@ -102,6 +101,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
             
         self.m486_list.append({"index": index, "name": None})
         self.last_m486 = index
+        self._console_logger.info(self.m486_list)
         return None
 
 # stolen directly from filaswitch, https://github.com/spegelius/filaswitch

--- a/octoprint_cancelobject/__init__.py
+++ b/octoprint_cancelobject/__init__.py
@@ -74,7 +74,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
         if matched:
             last_m486 = int(matched.group(1))
             self._console_logger.info("Matched {}".format(last_m486))
-            if last_m486 > -1:
+            if last_m486 != -1:
                 obj_name = self._get_m846(last_m486)
                 if obj_name:
                     self._console_logger.info(obj_name)
@@ -82,6 +82,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                     return line
             else:
                 line = line+"{0}stop\n".format(self._reptag)
+                return line
 
         #if we didn't match a control, it is going to be the descriptor
         else:
@@ -92,7 +93,7 @@ class ModifyComments(octoprint.filemanager.util.LineProcessorStream):
                     if each["index"] == self.last_m486:
                         each["name"] = descriptor.group(1)
                         self.last_m486 = None   
-        return line 
+            return line 
             
     def _get_m846(self, index):
         for each in self.m486_list:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_cancelobject"
 plugin_name = "OctoPrint-Cancelobject"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.4.7"
+plugin_version = "0.5.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Parser M486 commands from PrusaSlicer. This allows Label Objects setting to use either `OctoPrint Comments` or `Firmware Specific`.